### PR TITLE
fixed checkmate &  selecting a nilPiece when making a move

### DIFF
--- a/Game.rb
+++ b/Game.rb
@@ -27,6 +27,8 @@ class Game
           sleep(1.5)
         end
       end
+      swap_turn!
+      puts "Game Over, #{current_player} wins"
     end
 
   private

--- a/board.rb
+++ b/board.rb
@@ -100,11 +100,14 @@ class Board
   end
 
   def checkmate?(color)
-    return false unless in_check?(color)
+    return false unless in_check?(color) 
 
-    pieces.select { |p| p.color == color }.all? do |piece|
-      piece.valid_moves.empty?
+    if find_king(color).valid_moves.empty? 
+      "Game over"
     end
+    # pieces.select { |p| p.color == color }.all? do |piece|
+    #   piece.valid_moves.empty?
+    # end
   end
 
   def find_king(color)

--- a/cursor.rb
+++ b/cursor.rb
@@ -55,7 +55,7 @@ class Cursor
     case key
     when :ctrl_c
       exit 0
-    when :return, :space
+    when :return, :space, :newline
       toggle_selected
       cursor_pos
     when :left, :right, :up, :down

--- a/pieces/piece.rb
+++ b/pieces/piece.rb
@@ -26,6 +26,7 @@ class Piece
   end
 
   def valid_moves
+    raise "That is not a piece. Select one of your pieces to move" if moves.nil?
     moves.reject do |pos|
       move_into_check?(pos)
     end


### PR DESCRIPTION
Fixed the issue when selecting an empty square killing the game.  Each piece besides Nil has a moves method. When calling .moves on a nil piece will always return nil. Now if a nullPiece is selected, it raises and error and you select again. 

Played until checkmate and got an error. For the checkmate method, we only need to know if the king has no moves rather than all pieces. Made a change to only check if the king has no valid moves && is in check.

Finally when getting a checkmate, created a line in the play class to say " {#color} won", but kept getting the wrong color. After each turn the current player changes regardless if the game is over. Added another !swap_turn before printing the winner to correct this. 